### PR TITLE
sparse: disabled_services: Disable LiveDisplay

### DIFF
--- a/sparse/usr/libexec/droid-hybris/system/etc/init/disabled_services.rc
+++ b/sparse/usr/libexec/droid-hybris/system/etc/init/disabled_services.rc
@@ -25,6 +25,9 @@ service surfaceflinger surfaceflinger_HYBRIS_DISABLED
 
 service bootanim /system/bin/bootanimation_HYBRIS_DISABLED
 
+service vendor.livedisplay-hal-2-0 /vendor/bin/hw/vendor.lineage.livedisplay@2.0-service.oneplus_msmnile_HYBRIS_DISABLED
+	override
+
 service vendor.usb-hal-1-0 /vendor/bin/hw/android.hardware.usb@1.0-service_HYBRIS_DISABLED
 
 service vendor.vibrator-1-0 /vendor/bin/hw/android.hardware.vibrator@1.0-service_HYBRIS_DISABLED


### PR DESCRIPTION
Causes spam to tombstones and probably logcat (although haven't checked logcat)